### PR TITLE
Fix UInt8 parsing to enable DBF header tests

### DIFF
--- a/ShapeSwift.xcodeproj/xcshareddata/xcschemes/ShapeSwift.xcscheme
+++ b/ShapeSwift.xcodeproj/xcshareddata/xcschemes/ShapeSwift.xcscheme
@@ -38,20 +38,6 @@
                BlueprintName = "ShapeSwiftTests"
                ReferencedContainer = "container:ShapeSwift.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "DBFFileHeaderTest/testDBASE83()">
-               </Test>
-               <Test
-                  Identifier = "DBFFileHeaderTest/testDBASE83NoMemo()">
-               </Test>
-               <Test
-                  Identifier = "DBFFileHeaderTest/testDBASE8B()">
-               </Test>
-               <Test
-                  Identifier = "DBFFileHeaderTest/testDBASEF5()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/ShapeSwift/ByteParseable.swift
+++ b/ShapeSwift/ByteParseable.swift
@@ -110,9 +110,9 @@ extension Int8: SingleByteParseable {
 }
 
 extension UInt8: SingleByteParseable {
-  typealias ValueT = Int8
+  typealias ValueT = UInt8
   init?(data: Data, location: Int) {
-    self = UInt8(Int8(data: data, location: location)!)
+    self = dataBitPattern(fromData: data, start: location, sizeBytes: 1)
   }
 }
 
@@ -155,9 +155,9 @@ fileprivate extension ByteParseable {
 }
 
 fileprivate func dataBitPattern<T>(fromData data: Data, start: Int, sizeBytes: Int) -> T {
-  return data.withUnsafeBytes({(bytePointer: UnsafePointer<Byte>) -> T in
+  return data.withUnsafeBytes { (bytePointer: UnsafePointer<Byte>) -> T in
     bytePointer.advanced(by: start).withMemoryRebound(to: T.self, capacity: sizeBytes) { pointer in
       return pointer.pointee
     }
-  })
+  }
 }


### PR DESCRIPTION
Our code previously coundn't handle parsing UInt8s which were negative when represented as Int8s.
